### PR TITLE
fix(react): correct `sliceZone` prop type for `<SliceSimulator>`

### DIFF
--- a/packages/react/src/SliceSimulator.tsx
+++ b/packages/react/src/SliceSimulator.tsx
@@ -18,9 +18,7 @@ import {
 
 export type SliceSimulatorProps = {
 	className?: string;
-	sliceZone: (args: {
-		slices: SliceSimulatorState["slices"];
-	}) => React.ComponentType;
+	sliceZone: (props: { slices: SliceSimulatorState["slices"] }) => JSX.Element;
 } & _SliceSimulatorProps;
 
 const coreManager = new CoreManager();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes the type for `<SliceSimulator>`'s `sliceZone` prop. It replaces the props' function's return type from `React.ComponentType` to `JSX.Element`.

See this comment for the details on the error users will current see: https://github.com/prismicio/slice-machine/issues/430#issuecomment-1083103192

**Background info**: `React.ComponentType` is the type for a component, such as a function component (`() => JSX.Element`) or class component. `JSX.Element` is a low-level type that represents the return type of a component that returns JSX.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦆
