### PR TITLE
fix: add `fp-ts` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,9 +5093,9 @@
 			}
 		},
 		"node_modules/fp-ts": {
-			"version": "2.11.9",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.9.tgz",
-			"integrity": "sha512-GhYlNKkCOfdjp71ocdtyaQGoqCswEoWDJLRr+2jClnBBq2dnSOtd6QxmJdALq8UhfqCyZZ0f0lxadU4OhwY9nw=="
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+			"integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
 		},
 		"node_modules/fraction.js": {
 			"version": "4.2.0",
@@ -12318,6 +12318,7 @@
 			"dependencies": {
 				"@prismicio/slice-simulator-com": "^0.3.1",
 				"@prismicio/types": "^0.1.27",
+				"fp-ts": "^2.12.1",
 				"io-ts": "^2.2.16"
 			},
 			"devDependencies": {
@@ -12986,7 +12987,7 @@
 		},
 		"packages/react": {
 			"name": "@prismicio/slice-simulator-react",
-			"version": "0.2.1",
+			"version": "0.2.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/slice-simulator-core": "^0.2.1"
@@ -13010,7 +13011,7 @@
 		},
 		"packages/vue": {
 			"name": "@prismicio/slice-simulator-vue",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/slice-simulator-core": "^0.2.1"
@@ -13039,7 +13040,7 @@
 		},
 		"packages/vue3": {
 			"name": "@prismicio/slice-simulator-vue3",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/slice-simulator-core": "^0.2.1"
@@ -13606,6 +13607,7 @@
 				"@types/jsdom-global": "^3.0.2",
 				"@types/sinon": "^10.0.11",
 				"ava": "^3.15.0",
+				"fp-ts": "^2.12.1",
 				"io-ts": "^2.2.16",
 				"jsdom": "^19.0.0",
 				"jsdom-global": "^3.0.2",
@@ -17276,9 +17278,9 @@
 			}
 		},
 		"fp-ts": {
-			"version": "2.11.9",
-			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.9.tgz",
-			"integrity": "sha512-GhYlNKkCOfdjp71ocdtyaQGoqCswEoWDJLRr+2jClnBBq2dnSOtd6QxmJdALq8UhfqCyZZ0f0lxadU4OhwY9nw=="
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
+			"integrity": "sha512-oxvgqUYR6O9VkKXrxkJ0NOyU0FrE705MeqgBUMEPWyTu6Pwn768cJbHChw2XOBlgFLKfIHxjr2OOBFpv2mUGZw=="
 		},
 		"fraction.js": {
 			"version": "4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
 	"dependencies": {
 		"@prismicio/slice-simulator-com": "^0.3.1",
 		"@prismicio/types": "^0.1.27",
+		"fp-ts": "^2.12.1",
 		"io-ts": "^2.2.16"
 	},
 	"devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds `fp-ts` as a dependency. `@prismicio/slice-simulator-core` uses `io-ts` as a dependency, which declares `fp-ts` as a peer dependency.

When using npm &lt; 7, `fp-ts` is not installed automatically. The CI in this repository uses Node 16, which includes npm >= 7 and automatically installs `fp-ts`, thus the missing dependency does not fail tests.

Since Node 14 is currently LTS, includes npm &lt; 7, and is the lowest version of Node we support, we must list `fp-ts` as a dependency for down-stream consumers of `@prismicio/slice-simulator-core` (such as `@slicemachine/adapter-next`).

See this `@slicemachine/adapter-next` CI run for an example where `fp-ts` was not installed on Node 14: https://github.com/prismicio/slicemachine-adapter-next/runs/7266557159?check_suite_focus=true

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐧
