### PR TITLE
Don't load all slices in development

### DIFF
--- a/packages/core/src/StateManager.ts
+++ b/packages/core/src/StateManager.ts
@@ -78,8 +78,10 @@ export class StateManager extends EventEmitter<StateManagerEvents> {
 		// Load state
 		this._managedState = await this.load(state);
 
-		// Init slice zone
-		await this.forceSliceChunksDownload();
+		if (process.env.NODE_ENV !== "development") {
+			// Load all slices at once to prevent any flickering
+			await this.forceSliceChunksDownload();
+		}
 		this.setDefaultSliceZone();
 
 		// Defering event to allow for chunks to load in background


### PR DESCRIPTION
Because Nextjs forces display of an error popup when "something" breaks "somewhere",
loading one broken slice (eg. because of lack of mocks for content relationships) displays the popup on each slice preview.

This makes sure you can still work on other slices while fixing the slice at fault / waiting for a fix.