### PR TITLE
feat: hide the Prismic toolbar when initialized

### DIFF
--- a/src/kit/SimulatorManager.ts
+++ b/src/kit/SimulatorManager.ts
@@ -58,8 +58,8 @@ export class SimulatorManager {
 			return;
 		}
 
-		// Init listeners
 		this._initListeners();
+		this._injectGlobalStyles();
 	}
 
 	private async _initAPI(): Promise<void> {
@@ -194,5 +194,25 @@ export class SimulatorManager {
 				childList: true,
 			});
 		}
+	}
+
+	private _injectGlobalStyles() {
+		if (
+			document.querySelector(
+				"style[data-slice-simulator-prismic-toolbar-styles]",
+			)
+		) {
+			return;
+		}
+
+		// A basic <style> tag is used over CSSStyleSheet for greater
+		// browser compatibility.
+		const style = document.createElement("style");
+		style.dataset.sliceSimulatorPrismicToolbarStyles = "";
+
+		style.innerText =
+			"iframe#prismic-toolbar-v2 { visibility: hidden !important; }";
+
+		document.head.appendChild(style);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR automatically hides the Prismic toolbar when the simulator is initialized.

`SimulatorManager` injects a `<style>` element to the document's head with the following CSS:

```css
iframe#prismic-toolbar-v2 {
  visibility: hidden !important;
}
```

The above CSS targets the Prismic toolbar's iframe and hides it from view. The toolbar continues to function in the background.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
