### PR TITLE
fix: observe existing simulator root for size updates

### DIFF
--- a/src/kit/SimulatorManager.ts
+++ b/src/kit/SimulatorManager.ts
@@ -179,6 +179,7 @@ export class SimulatorManager {
 				subtree: false,
 				childList: true,
 			})
+			observeSimulatorRoot()
 		}
 	}
 }

--- a/test/kit-SimulatorManager.test.ts
+++ b/test/kit-SimulatorManager.test.ts
@@ -3,6 +3,7 @@ import { expect, it, vi } from "vitest"
 import { SimulatorAPI } from "../src/SimulatorAPI"
 import type { UnknownRequestMessage } from "../src/channel"
 import { createSuccessResponseMessage } from "../src/channel"
+import { simulatorClass, simulatorRootClass } from "../src/kit/domHelpers"
 import { sliceSimulatorAccessedDirectly } from "../src/kit/messages"
 import { SimulatorManager } from "../src/kit/SimulatorManager"
 
@@ -42,4 +43,37 @@ it("doesn't initialize API when not embedded and sets message", async () => {
 	// @ts-expect-error - taking a shortcut by accessing private property
 	expect(manager._api).toBeNull()
 	expect(manager.state.message).toBe(sliceSimulatorAccessedDirectly)
+})
+
+it("observes an existing simulator root when slice zone size API is enabled", () => {
+	document.body.innerHTML = `<div class="${simulatorClass}">
+		<div class="${simulatorRootClass}"></div>
+	</div>`
+
+	const observeMock = vi.fn()
+	vi.stubGlobal(
+		"ResizeObserver",
+		vi.fn(function ResizeObserverMock() {
+			return {
+				disconnect: vi.fn(),
+				observe: observeMock,
+			}
+		}),
+	)
+
+	try {
+		const manager = new SimulatorManager()
+		// @ts-expect-error - taking a shortcut by accessing private property
+		manager._api = { options: { sliceZoneSizeAPI: true } }
+
+		// @ts-expect-error - taking a shortcut by accessing private method
+		manager._initListeners()
+
+		expect(observeMock).toHaveBeenCalledWith(
+			document.querySelector(`.${simulatorRootClass}`),
+		)
+	} finally {
+		document.body.innerHTML = ""
+		vi.unstubAllGlobals()
+	}
 })


### PR DESCRIPTION
### Description

Fixes slice zone size updates when `.slice-simulator--root` already exists before `SimulatorManager` initializes its listeners.

The existing `MutationObserver` only handles roots added later. This calls the existing observer setup once during listener initialization and adds a regression test for that behavior.

### Checklist

- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### How to QA

- Run `npm run test`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/slice-simulator/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782301087&installation_id=125473232&pr_number=27&repository=prismicio%2Fslice-simulator&return_to=https%3A%2F%2Fgithub.com%2Fprismicio%2Fslice-simulator%2Fpull%2F27&signature=22a051b74e14ddacf3dd4e03e8ea4bbbd4f34cb20e31576e48f877145643a214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small listener-init fix plus a unit test; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **slice zone size** reporting when `.slice-simulator--root` is already in the DOM before listeners start. A `MutationObserver` only ran `observeSimulatorRoot` when children were added later, so an existing root never got a `ResizeObserver` until the DOM changed again.
> 
> `SimulatorManager` now calls `observeSimulatorRoot()` once right after wiring the mutation observer, reusing the same hook that attaches the resize observer. A regression test stubs `ResizeObserver` and asserts the existing root is observed when `sliceZoneSizeAPI` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727b2a142def8188aa106a29e3bf07f3b19fd5b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->